### PR TITLE
Sentinel Objects

### DIFF
--- a/escudeiro/ds/__init__.py
+++ b/escudeiro/ds/__init__.py
@@ -6,7 +6,7 @@ from .pools.asyncio import AsyncPool
 from .pools.thread import ThreadPool
 from .registry import CallableRegistry, Registry
 from .scheduler import CronInfo, Task, TaskScheduler
-from .sentinel import Sentinel
+from .sentinels import sentinel
 from .worker import WorkerQueue
 
 __all__ = [
@@ -23,5 +23,5 @@ __all__ = [
     "VirtualFileTree",
     "Registry",
     "CallableRegistry",
-    "Sentinel",
+    "sentinel",
 ]

--- a/escudeiro/ds/__init__.py
+++ b/escudeiro/ds/__init__.py
@@ -6,6 +6,7 @@ from .pools.asyncio import AsyncPool
 from .pools.thread import ThreadPool
 from .registry import CallableRegistry, Registry
 from .scheduler import CronInfo, Task, TaskScheduler
+from .sentinel import Sentinel
 from .worker import WorkerQueue
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "VirtualFileTree",
     "Registry",
     "CallableRegistry",
+    "Sentinel",
 ]

--- a/escudeiro/ds/sentinel.py
+++ b/escudeiro/ds/sentinel.py
@@ -1,0 +1,91 @@
+from typing import Any, TypeVar, override
+
+_registry: dict[str, Any] = {}
+T = TypeVar("T")
+
+
+class _BaseSentinel:
+    """Internal base for sentinel instances."""
+
+    @override
+    def __repr__(self) -> str:
+        name = object.__getattribute__(self, "_name")
+        value = object.__getattribute__(self, "_value")
+        if value is self:
+            return name
+        return f"{name}({value!r})"
+
+    @override
+    def __reduce__(self) -> tuple[type["_BaseSentinel"], tuple[str, str, Any]]:
+        return (
+            self.__class__,
+            (
+                object.__getattribute__(self, "_name"),
+                object.__getattribute__(self, "_module_name"),
+                object.__getattribute__(self, "_value"),
+            ),
+        )
+
+
+class Sentinel:
+    """Unique sentinel values.
+
+    This class is designed to be used as a decorator to create unique sentinel
+    objects. When a class is decorated with `@Sentinel`, it can either create
+    a single unique sentinel instance (if the decorated class is empty) or
+    a collection of unique sentinel instances (if the decorated class defines members).
+    """
+
+    def __new__(cls, decorated_cls: type[T]) -> T | Any:
+        name = decorated_cls.__name__
+        module_name = decorated_cls.__module__
+
+        members = {
+            k: v
+            for k, v in decorated_cls.__dict__.items()
+            if not k.startswith("__") and not callable(v)
+        }
+
+        if not members:
+            # Case 1: Single sentinel (e.g., @Sentinel class MISSING: pass)
+            registry_key = f"{module_name}-{name}"
+            sentinel_instance = _registry.get(registry_key, None)
+            if sentinel_instance is not None:
+                return sentinel_instance
+
+            sentinel_instance = _BaseSentinel.__new__(_BaseSentinel)
+            object.__setattr__(sentinel_instance, "_name", name)
+            object.__setattr__(sentinel_instance, "_module_name", module_name)
+            object.__setattr__(sentinel_instance, "_value", sentinel_instance)
+            _registry.setdefault(registry_key, sentinel_instance)
+            return sentinel_instance
+
+        # Case 2: Enum-like sentinel (e.g., @Sentinel class STATUS: PENDING = 1)
+        new_type = type(name, (object,), {})
+        object.__setattr__(new_type, "__module__", module_name)
+
+        for member_name, member_value in members.items():
+            member_sentinel_name = f"{name}.{member_name}"
+            member_sentinel_module = module_name
+
+            registry_key = f"{member_sentinel_module}-{member_sentinel_name}"
+            member_sentinel_instance = _registry.get(registry_key, None)
+
+            if member_sentinel_instance is None:
+                member_sentinel_instance = _BaseSentinel.__new__(_BaseSentinel)
+                object.__setattr__(
+                    member_sentinel_instance, "_name", member_sentinel_name
+                )
+                object.__setattr__(
+                    member_sentinel_instance,
+                    "_module_name",
+                    member_sentinel_module,
+                )
+                object.__setattr__(
+                    member_sentinel_instance, "_value", member_value
+                )
+                _registry.setdefault(registry_key, member_sentinel_instance)
+
+            setattr(new_type, member_name, member_sentinel_instance)
+
+        return new_type

--- a/escudeiro/ds/sentinels.py
+++ b/escudeiro/ds/sentinels.py
@@ -1,7 +1,6 @@
-from typing import Any, TypeVar, override
+from typing import Any, final, override
 
 _registry: dict[str, Any] = {}
-T = TypeVar("T")
 
 
 class _BaseSentinel:
@@ -9,11 +8,10 @@ class _BaseSentinel:
 
     @override
     def __repr__(self) -> str:
-        name = object.__getattribute__(self, "_name")
         value = object.__getattribute__(self, "_value")
         if value is self:
-            return name
-        return f"{name}({value!r})"
+            return value
+        return f"{value!r}"
 
     @override
     def __reduce__(self) -> tuple[type["_BaseSentinel"], tuple[str, str, Any]]:
@@ -27,6 +25,7 @@ class _BaseSentinel:
         )
 
 
+@final
 class Sentinel:
     """Unique sentinel values.
 
@@ -36,7 +35,7 @@ class Sentinel:
     a collection of unique sentinel instances (if the decorated class defines members).
     """
 
-    def __new__(cls, decorated_cls: type[T]) -> T | Any:
+    def __new__[T](cls, decorated_cls: type[T]) -> _BaseSentinel | type[Any]:
         name = decorated_cls.__name__
         module_name = decorated_cls.__module__
 
@@ -61,8 +60,7 @@ class Sentinel:
             return sentinel_instance
 
         # Case 2: Enum-like sentinel (e.g., @Sentinel class STATUS: PENDING = 1)
-        new_type = type(name, (object,), {})
-        object.__setattr__(new_type, "__module__", module_name)
+        new_type = type(name, (object,), {"__module__": module_name})
 
         for member_name, member_value in members.items():
             member_sentinel_name = f"{name}.{member_name}"

--- a/escudeiro/ds/sentinels.py
+++ b/escudeiro/ds/sentinels.py
@@ -1,20 +1,21 @@
-from typing import Any, final, override
+from typing import Any, cast, override
 
 _registry: dict[str, Any] = {}
 
 
-class _BaseSentinel:
+class Sentinel:
     """Internal base for sentinel instances."""
 
     @override
     def __repr__(self) -> str:
+        name = object.__getattribute__(self, "_name")
         value = object.__getattribute__(self, "_value")
         if value is self:
-            return value
+            return name
         return f"{value!r}"
 
     @override
-    def __reduce__(self) -> tuple[type["_BaseSentinel"], tuple[str, str, Any]]:
+    def __reduce__(self) -> tuple[type["Sentinel"], tuple[str, str, Any]]:
         return (
             self.__class__,
             (
@@ -25,65 +26,47 @@ class _BaseSentinel:
         )
 
 
-@final
-class Sentinel:
+def sentinel[T](cls: type[T]) -> T:
     """Unique sentinel values.
 
     This class is designed to be used as a decorator to create unique sentinel
-    objects. When a class is decorated with `@Sentinel`, it can either create
+    objects. When a class is decorated with `@sentinel`, it can either create
     a single unique sentinel instance (if the decorated class is empty) or
     a collection of unique sentinel instances (if the decorated class defines members).
     """
+    name = cls.__name__
+    module_name = cls.__module__
 
-    def __new__[T](cls, decorated_cls: type[T]) -> _BaseSentinel | type[Any]:
-        name = decorated_cls.__name__
-        module_name = decorated_cls.__module__
+    members = {
+        k: v
+        for k, v in cls.__dict__.items()
+        if not k.startswith("__") and not callable(v)
+    }
 
-        members = {
-            k: v
-            for k, v in decorated_cls.__dict__.items()
-            if not k.startswith("__") and not callable(v)
-        }
-
-        if not members:
-            # Case 1: Single sentinel (e.g., @Sentinel class MISSING: pass)
-            registry_key = f"{module_name}-{name}"
-            sentinel_instance = _registry.get(registry_key, None)
-            if sentinel_instance is not None:
-                return sentinel_instance
-
-            sentinel_instance = _BaseSentinel.__new__(_BaseSentinel)
-            object.__setattr__(sentinel_instance, "_name", name)
-            object.__setattr__(sentinel_instance, "_module_name", module_name)
-            object.__setattr__(sentinel_instance, "_value", sentinel_instance)
-            _registry.setdefault(registry_key, sentinel_instance)
+    # Case 1: Single sentinel (e.g., @sentinel class MISSING: pass)
+    if not members:
+        registry_key = f"{module_name}-{name}"
+        sentinel_instance = _registry.get(registry_key, None)
+        if sentinel_instance is not None:
             return sentinel_instance
 
-        # Case 2: Enum-like sentinel (e.g., @Sentinel class STATUS: PENDING = 1)
-        new_type = type(name, (object,), {"__module__": module_name})
+        sentinel_instance = Sentinel.__new__(Sentinel)
+        object.__setattr__(sentinel_instance, "_name", name)
+        object.__setattr__(sentinel_instance, "_module_name", module_name)
+        object.__setattr__(sentinel_instance, "_value", sentinel_instance)
+        _registry.setdefault(registry_key, sentinel_instance)
+        return cast(T, sentinel_instance)
 
-        for member_name, member_value in members.items():
-            member_sentinel_name = f"{name}.{member_name}"
-            member_sentinel_module = module_name
+    # Case 2: Enum-like sentinel (e.g., @sentinel class STATUS: PENDING = 1)
+    new_type = type(name, (object,), {"__module__": module_name})
 
-            registry_key = f"{member_sentinel_module}-{member_sentinel_name}"
-            member_sentinel_instance = _registry.get(registry_key, None)
+    for member_name, member_value in members.items():
+        member_sentinel_name = f"{name}.{member_name}"
+        member_sentinel_module = module_name
 
-            if member_sentinel_instance is None:
-                member_sentinel_instance = _BaseSentinel.__new__(_BaseSentinel)
-                object.__setattr__(
-                    member_sentinel_instance, "_name", member_sentinel_name
-                )
-                object.__setattr__(
-                    member_sentinel_instance,
-                    "_module_name",
-                    member_sentinel_module,
-                )
-                object.__setattr__(
-                    member_sentinel_instance, "_value", member_value
-                )
-                _registry.setdefault(registry_key, member_sentinel_instance)
+        registry_key = f"{member_sentinel_module}-{member_sentinel_name}"
+        final_value = _registry.setdefault(registry_key, member_value)
 
-            setattr(new_type, member_name, member_sentinel_instance)
+        setattr(new_type, member_name, final_value)
 
-        return new_type
+    return cast(T, new_type)

--- a/escudeiro/ds/sentinels.py
+++ b/escudeiro/ds/sentinels.py
@@ -10,9 +10,7 @@ class Sentinel:
     def __repr__(self) -> str:
         name = object.__getattribute__(self, "_name")
         value = object.__getattribute__(self, "_value")
-        if value is self:
-            return name
-        return f"{value!r}"
+        return name if value is self else f"{value!r}"
 
     @override
     def __reduce__(self) -> tuple[type["Sentinel"], tuple[str, str, Any]]:

--- a/tests/ds/test_sentinels.py
+++ b/tests/ds/test_sentinels.py
@@ -1,0 +1,168 @@
+import pickle
+
+from escudeiro.ds.sentinels import Sentinel, _registry, sentinel
+
+
+class TestSentinel:
+    def test_repr_single_sentinel(self) -> None:
+        @sentinel
+        class MISSING:
+            pass
+
+        assert repr(MISSING) == "MISSING"
+
+    def test_repr_enum_like_sentinel(self) -> None:
+        @sentinel
+        class STATUS:
+            PENDING = 1
+            COMPLETED = 2
+
+        assert repr(STATUS.PENDING) == "1"
+        assert repr(STATUS.COMPLETED) == "2"
+
+    def test_reduce_single_sentinel(self) -> None:
+        @sentinel
+        class MISSING:
+            pass
+
+        reduced = MISSING.__reduce__()
+        assert reduced[0] is Sentinel
+        assert reduced[1] == ("MISSING", "tests.ds.test_sentinels", MISSING)
+
+        pickled = pickle.dumps(MISSING)
+        unpickled = pickle.loads(pickled)
+        assert unpickled is MISSING
+
+    def test_reduce_enum_like_sentinel(self) -> None:
+        @sentinel
+        class STATUS:
+            PENDING = 1
+            COMPLETED = 2
+
+        reduced_pending = STATUS.PENDING.__reduce__()
+        assert reduced_pending[0] is Sentinel
+        assert reduced_pending[1] == (
+            "STATUS.PENDING",
+            "tests.ds.test_sentinels",
+            1,
+        )
+
+        reduced_completed = STATUS.COMPLETED.__reduce__()
+        assert reduced_completed[0] is Sentinel
+        assert reduced_completed[1] == (
+            "STATUS.COMPLETED",
+            "tests.ds.test_sentinels",
+            2,
+        )
+
+        pickled_pending = pickle.dumps(STATUS.PENDING)
+        unpickled_pending = pickle.loads(pickled_pending)
+        assert unpickled_pending is STATUS.PENDING
+
+        pickled_completed = pickle.dumps(STATUS.COMPLETED)
+        unpickled_completed = pickle.loads(pickled_completed)
+        assert unpickled_completed is STATUS.COMPLETED
+
+
+class TestSentinelDecorator:
+    def setup_method(self) -> None:
+        _registry.clear()
+
+    def test_single_sentinel_creation(self) -> None:
+        @sentinel
+        class MISSING:
+            pass
+
+        assert isinstance(MISSING, Sentinel)
+        assert repr(MISSING) == "MISSING"
+        assert MISSING is sentinel(MISSING.__class__)  # Ensure uniqueness
+
+    def test_single_sentinel_uniqueness_across_calls(self) -> None:
+        @sentinel
+        class MISSING_A:
+            pass
+
+        @sentinel
+        class MISSING_B:
+            pass
+
+        assert MISSING_A is not MISSING_B
+
+        @sentinel
+        class MISSING_A_AGAIN:
+            pass
+
+        assert MISSING_A is MISSING_A_AGAIN
+
+    def test_enum_like_sentinel_creation(self) -> None:
+        @sentinel
+        class STATUS:
+            PENDING = 1
+            COMPLETED = 2
+            CANCELLED = "cancelled"
+
+        assert hasattr(STATUS, "PENDING")
+        assert hasattr(STATUS, "COMPLETED")
+        assert hasattr(STATUS, "CANCELLED")
+
+        assert STATUS.PENDING == 1
+        assert STATUS.COMPLETED == 2
+        assert STATUS.CANCELLED == "cancelled"
+
+        assert repr(STATUS.PENDING) == "1"
+        assert repr(STATUS.COMPLETED) == "2"
+        assert repr(STATUS.CANCELLED) == "'cancelled'"
+
+    def test_enum_like_sentinel_uniqueness(self) -> None:
+        @sentinel
+        class STATUS_A:
+            PENDING = 1
+
+        @sentinel
+        class STATUS_B:
+            PENDING = 1
+
+        assert STATUS_A.PENDING is not STATUS_B.PENDING
+
+        @sentinel
+        class STATUS_A_AGAIN:
+            PENDING = 1
+
+        assert STATUS_A.PENDING is STATUS_A_AGAIN.PENDING
+
+    def test_sentinel_with_callable_members_ignored(self) -> None:
+        @sentinel
+        class MY_SENTINEL:
+            VALUE = 1
+
+            def my_method(self) -> int:
+                return 10
+
+        assert hasattr(MY_SENTINEL, "VALUE")
+        assert not hasattr(MY_SENTINEL, "my_method")
+
+    def test_sentinel_with_dunder_members_ignored(self) -> None:
+        @sentinel
+        class MY_SENTINEL:
+            VALUE = 1
+            __dunder_value__ = 2
+
+        assert hasattr(MY_SENTINEL, "VALUE")
+        assert not hasattr(MY_SENTINEL, "__dunder_value__")
+
+    def test_sentinel_registry_persistence(self) -> None:
+        @sentinel
+        class FIRST_CALL:
+            pass
+
+        assert "tests.ds.test_sentinels-FIRST_CALL" in _registry
+        assert _registry["tests.ds.test_sentinels-FIRST_CALL"] is FIRST_CALL
+
+        @sentinel
+        class STATUS_REGISTRY:
+            ITEM = 1
+
+        _ = STATUS_REGISTRY.ITEM
+
+        assert "tests.ds.test_sentinels-STATUS_REGISTRY.ITEM" in _registry
+        assert _registry["tests.ds.test_sentinels-STATUS_REGISTRY.ITEM"] == 1


### PR DESCRIPTION
## Unreleased

### BREAKING CHANGE

- sentinel objects are working now

### Feat

- **sentinel.py**: added basic sentinel objects logic
- added jsonx and config

### Fix

- **sentinels.py**: fixed type casting for enum-like sentinels
- **sentinels**: renamed module name

## Summary by Sourcery

Introduce a sentinel decorator and base class to generate unique singleton and enum-like sentinel objects with consistent repr, pickling support, and global registry; expose sentinel in the package API and add comprehensive tests

New Features:
- Add sentinel decorator to produce singleton and enum-like sentinel instances
- Implement Sentinel class with custom repr, reduce, and registry persistence
- Expose sentinel in the ds module's public API

Bug Fixes:
- Ensure enum-like sentinel members maintain their original values and repr
- Fix pickling behavior for both single and enum-like sentinels

Tests:
- Add extensive tests covering sentinel creation, uniqueness, repr, pickling, and registry behavior