### PR TITLE
Added dark theme to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,19 @@ theme:
     - content.code.copy
     - content.code.annotate
     - content.action.edit
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 repo_url: https://github.com/guscardvs/escudeiro
 repo_name: guscardvs/escudeiro
 nav:
@@ -20,24 +33,24 @@ nav:
       - Lazy Fields: features/lazyfields.md
       - URL Utilities: features/url.md
       - Miscellaneous:
-        - Context Utilities: features/misc/context.md
-        - Enum Utilities: features/misc/enums.md
-        - Useful functions: features/misc/functions.md
-        - Iterables and Sequences: features/misc/iter.md
-        - JSON Utilities: features/misc/json.md
-        - Lazy Methods: features/misc/lazy.md
-        - String Utilities: features/misc/strings.md
-        - Timezone Utilities: features/misc/timezone.md
-        - Type Utilities: features/misc/type.md
+          - Context Utilities: features/misc/context.md
+          - Enum Utilities: features/misc/enums.md
+          - Useful functions: features/misc/functions.md
+          - Iterables and Sequences: features/misc/iter.md
+          - JSON Utilities: features/misc/json.md
+          - Lazy Methods: features/misc/lazy.md
+          - String Utilities: features/misc/strings.md
+          - Timezone Utilities: features/misc/timezone.md
+          - Type Utilities: features/misc/type.md
       - Datastructures:
-        - Worker: features/datastructures/worker.md
-        - Scheduler: features/datastructures/scheduler.md
-        - Task Manager: features/datastructures/manager.md
-        - Circuit Breaker: features/datastructures/circuit.md
-        - Pools: features/datastructures/pools.md
-        - Filetree: features/datastructures/filetree.md
-        - Registry: features/datastructures/registry.md
-        - Sentinels: features/datastructures/sentinels.md
+          - Worker: features/datastructures/worker.md
+          - Scheduler: features/datastructures/scheduler.md
+          - Task Manager: features/datastructures/manager.md
+          - Circuit Breaker: features/datastructures/circuit.md
+          - Pools: features/datastructures/pools.md
+          - Filetree: features/datastructures/filetree.md
+          - Registry: features/datastructures/registry.md
+          - Sentinels: features/datastructures/sentinels.md
       - Data Classes: features/data.md
       - Context Management and Resource Usage: features/context.md
       - Configuration and Environment: features/config.md


### PR DESCRIPTION
Added theme toggle to mkdocs.yml

## Summary by Sourcery

Add light/dark theme toggle to the MkDocs configuration and correct navigation indentation

Enhancements:
- Configure default and slate color palettes with toggle icons and labels in mkdocs.yml

Documentation:
- Fix indentation of navigation items under Miscellaneous and Datastructures sections